### PR TITLE
fix: Revert "ci(deps): update dependency skopeo to v1.23.0"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
-  SKOPEO_VERSION: 1.23.0 # renovate: datasource=github-releases depName=skopeo packageName=visualon/skopeo-prebuild versioning=semver
+  SKOPEO_VERSION: 1.22.2 # renovate: datasource=github-releases depName=skopeo packageName=visualon/skopeo-prebuild versioning=semver
 
 permissions:
   contents: read


### PR DESCRIPTION
Reverts containerbase/ubuntu#570

broken: https://github.com/containers/skopeo/releases/tag/v1.23.0